### PR TITLE
Typo: priave instead of private

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ The only file users should modify is `config.json`. It is intended to encompass 
   - `ssh (boolean)` - Enabling this will make sure you have SSH keys setup, generating them if needed. When keys are generated, the public key will be printed to the console. Please make sure to add this public key to any git remotes you intend to communicate with using SSH.
   - `repos ({string: string})` - Git repositories you want Paltry to clone automatically on your behalf. The local folder to use is the key with the remote URL as the value.
 - `maven (object)`
-  - `servers ([string])` - If you use priave Maven repos (such as a Nexus server) then add their ids in an array to this property. The build will prompt for your credentials and will save encrypted versions of them to `settings.xml`. Different credentials per server are not supported at this time.
+  - `servers ([string])` - If you use private Maven repos (such as a Nexus server) then add their ids in an array to this property. The build will prompt for your credentials and will save encrypted versions of them to `settings.xml`. Different credentials per server are not supported at this time.
 
 ## License
 


### PR DESCRIPTION
Fixed a typo: priave instead of private